### PR TITLE
Should be placed in root according to docs

### DIFF
--- a/public/versel.json
+++ b/public/versel.json
@@ -1,6 +1,0 @@
-{
-  "routes": [
-    { "handle": "filesystem" },
-    { "src": "/(.*)", "dest": "/index.html" }
-  ]
-}

--- a/versel.json
+++ b/versel.json
@@ -1,5 +1,6 @@
 {
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
   ]
 }


### PR DESCRIPTION
ChatGPT falsely seem to claim vercel.json should be placed in the public directory for SPAs, but according to the documentation I could find (various people discussing it), it should be placed in the document root??